### PR TITLE
Fix notification polling lifecycle and persist like/retweet interaction state

### DIFF
--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -231,6 +231,7 @@ export default {
       newNotifications: 0,
       qrModalOpen: false,
       qrCode: "",
+      unsubscribeNotifications: null,
     };
   },
   mounted() {
@@ -280,9 +281,19 @@ export default {
 
     this.profile.avatar = await warpnetService.getImage({userId:this.profile.user_id, key:this.profile.avatar_key})
 
+    this.unsubscribeNotifications = warpnetService.subscribeNotifications((resp) => {
+      this.newNotifications = resp.unread_count || 0;
+    });
+
     const resp = await warpnetService.getNotifications(true)
     if (resp) {
       this.newNotifications = resp.unread_count;
+    }
+  },
+  beforeUnmount() {
+    if (this.unsubscribeNotifications) {
+      this.unsubscribeNotifications();
+      this.unsubscribeNotifications = null;
     }
   },
 };

--- a/src/components/TweetBlock.vue
+++ b/src/components/TweetBlock.vue
@@ -142,6 +142,18 @@ export default {
     };
   },
   methods: {
+    async refreshInteractionState() {
+      const owner = warpnetService.getOwnerProfile();
+      if (!owner) {
+        this.liked = false;
+        this.retweeted = false;
+        return;
+      }
+
+      this.liked = await warpnetService.hasLiker(this.tweet.id, owner.user_id);
+      this.retweeted = this.tweet.retweeted_by === owner.user_id
+        || await warpnetService.hasRetweeter(this.tweet.id, owner.user_id);
+    },
     gotoProfile(tweetUserId) {
       this.$router.push({
         name: "Profile",
@@ -196,15 +208,17 @@ export default {
         username: this.tweet.username,
         text: this.tweet.text,
       }
-      const alreadyRetweeted = await warpnetService.hasRetweeter(this.tweet.id, owner.user_id)
+      const alreadyRetweeted = this.retweeted
       try {
         if (!alreadyRetweeted) {
           await warpnetService.retweetTweet(retweetObject);
           await warpnetService.setRetweeter(this.tweet.id, owner.user_id, owner)
+          this.tweet.retweeted_by = owner.user_id;
           this.retweeted = true;
         } else {
           await warpnetService.unretweetTweet(this.tweet.id);
           await warpnetService.deleteRetweeter(this.tweet.id, owner.user_id)
+          this.tweet.retweeted_by = null;
           this.retweeted = false;
         }
       } catch (err) {
@@ -219,7 +233,7 @@ export default {
       const owner = warpnetService.getOwnerProfile();
       if (!owner) return;
       let likesNum = 0
-      const alreadyLiked = await warpnetService.hasLiker(this.tweet.id, owner.user_id)
+      const alreadyLiked = this.liked
       try {
         if (!alreadyLiked) {
           likesNum = await warpnetService.likeTweet(this.tweet.id, this.tweet.user_id)
@@ -276,11 +290,7 @@ export default {
 
     await this.loadTweetStats(this.tweet.id, this.tweet.user_id);
 
-    const owner = warpnetService.getOwnerProfile();
-    if (owner) {
-      this.liked = await warpnetService.hasLiker(this.tweet.id, owner.user_id);
-      this.retweeted = await warpnetService.hasRetweeter(this.tweet.id, owner.user_id);
-    }
+    await this.refreshInteractionState();
   },
 };
 </script>

--- a/src/service/service.js
+++ b/src/service/service.js
@@ -65,6 +65,8 @@ export const PUBLIC_POST_IS_FOLLOWING  = "/public/post/isfollowing/0.0.0"
 export const PUBLIC_POST_IS_FOLLOWER   = "/public/post/isfollower/0.0.0"
 
 const stateMap = new Map();
+const notificationSubscribers = new Set();
+let latestNotifications = { unread_count: 0, notifications: [] };
 const defaultLimit = 20
 const endCursor = "end"
 
@@ -97,6 +99,12 @@ export const warpnetService = {
     getOwnerProfile() {
         const key = `owner`;
         return stateMap.get(key)
+    },
+
+    clearOwnerProfile() {
+        const key = `owner`;
+        stateMap.delete(key)
+        stopRefreshNotifications()
     },
 
     async signInUser(form) {
@@ -312,7 +320,22 @@ export const warpnetService = {
             return {unread_count:0, notifications: []};
         }
         this.setCursor('notifications', resp.cursor || 'end')
+        latestNotifications = {
+            unread_count: resp.unread_count || 0,
+            notifications: resp.notifications || [],
+        };
+        for (const cb of notificationSubscribers) {
+            cb(latestNotifications);
+        }
         return resp;
+    },
+
+    subscribeNotifications(callback) {
+        notificationSubscribers.add(callback);
+        callback(latestNotifications);
+        return () => {
+            notificationSubscribers.delete(callback);
+        };
     },
 
     async getTweets({userId,cursorReset}) {
@@ -620,11 +643,15 @@ export const warpnetService = {
     async setLiker(tweetId, profileId, profileObj) {
         const cacheKey = `liker::${tweetId}::${profileId}`; // order matters
         stateMap.set(cacheKey, profileObj)
+        localStorage.setItem(cacheKey, "1")
     },
 
     async hasLiker(tweetId, profileId) {
         const cacheKey = `liker::${tweetId}::${profileId}`; // order matters
-        return stateMap.has(cacheKey)
+        if (stateMap.has(cacheKey)) {
+            return true
+        }
+        return localStorage.getItem(cacheKey) === "1"
     },
 
     async getLiker(tweetId, profileId) {
@@ -635,6 +662,7 @@ export const warpnetService = {
     async deleteLiker(tweetId, profileId) {
         const cacheKey = `liker::${tweetId}::${profileId}`; // order matters
         stateMap.delete(cacheKey)
+        localStorage.removeItem(cacheKey)
     },
 
     async retweetTweet({tweetId, userId, username, text}) {
@@ -673,11 +701,15 @@ export const warpnetService = {
     async setRetweeter(tweetId, profileId, profileObj) {
         const cacheKey = `retweeter::${tweetId}::${profileId}`; // order matters
         stateMap.set(cacheKey, profileObj)
+        localStorage.setItem(cacheKey, "1")
     },
 
     async hasRetweeter(tweetId, profileId) {
         const cacheKey = `retweeter::${tweetId}::${profileId}`; // order matters
-        return stateMap.has(cacheKey)
+        if (stateMap.has(cacheKey)) {
+            return true
+        }
+        return localStorage.getItem(cacheKey) === "1"
     },
 
     async getRetweeter(tweetId, profileId) {
@@ -688,6 +720,7 @@ export const warpnetService = {
     async deleteRetweeter(tweetId, profileId) {
         const cacheKey = `retweeter::${tweetId}::${profileId}`; // order matters
         stateMap.delete(cacheKey)
+        localStorage.removeItem(cacheKey)
     },
 
     async createChat(otherUserId) {
@@ -846,14 +879,31 @@ function sleep(ms) {
 }
 
 let notificationInterval = null;
+let notificationRefreshInFlight = false;
 
 export function startRefreshNotifications() {
     if (notificationInterval) return;
-    notificationInterval = setInterval(() => {
+    notificationInterval = setInterval(async () => {
         const owner = warpnetService.getOwnerProfile();
-        if (!owner) return;
-        warpnetService.getNotifications(true).catch(err => {
+        if (!owner) {
+            stopRefreshNotifications();
+            return;
+        }
+        if (notificationRefreshInFlight) return;
+        notificationRefreshInFlight = true;
+        try {
+            await warpnetService.getNotifications(true);
+        } catch (err) {
             console.error('failed to refresh notifications', err);
-        });
+        } finally {
+            notificationRefreshInFlight = false;
+        }
     }, 2000);
+}
+
+export function stopRefreshNotifications() {
+    if (!notificationInterval) return;
+    clearInterval(notificationInterval);
+    notificationInterval = null;
+    notificationRefreshInFlight = false;
 }


### PR DESCRIPTION
### Motivation
- Prevent wasted background work and leaked listeners by making notification polling stoppable and by surfacing poll results to the UI.
- Make likes/retweets reflect server/last-known state across reloads/sessions instead of only reading an ephemeral in-memory cache.

### Description
- Added notification state channel in the service (`notificationSubscribers`, `latestNotifications`, and `subscribeNotifications`) and updated `getNotifications` to store and broadcast the latest payload.
- Fixed polling lifecycle by introducing `stopRefreshNotifications()`, auto-stopping when no owner exists, and preventing overlapping refreshes with a `notificationRefreshInFlight` guard; added `clearOwnerProfile()` to clear owner and stop polling.
- Persisted like/retweet markers to `localStorage` in addition to the in-memory `stateMap` and updated `set/has/delete` helpers for `liker::...` and `retweeter::...` keys to consult localStorage as a fallback.
- Updated UI components: `SideNav` now subscribes/unsubscribes to notification updates (so unread badge follows polling results), and `TweetBlock` centralizes interaction resolution in `refreshInteractionState()`, derives retweet state from `tweet.retweeted_by` (with persisted fallback), and keeps `tweet.retweeted_by` synchronized on retweet/unretweet.

### Testing
- Ran `npm run build`, which completed successfully (build artifacts emitted and no fatal errors).
- No additional automated tests were present or modified; manual validation performed via the build and code inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd83c0d28c832c81a17a71707ba23b)